### PR TITLE
[LeanCopilotBot] `sorry` Removed by Lean Copilot

### DIFF
--- a/NewVersionTest/Basic.lean
+++ b/NewVersionTest/Basic.lean
@@ -1,7 +1,7 @@
 open Nat (add_assoc add_comm)
 
 theorem foo (a : Nat) : a + 1 = Nat.succ a := by
-  rfl
+  sorry
 
 theorem bar (a b : Nat) : a + b = b + a := by
   rw[add_comm]

--- a/NewVersionTest/Basic.lean
+++ b/NewVersionTest/Basic.lean
@@ -1,7 +1,7 @@
 open Nat (add_assoc add_comm)
 
 theorem foo (a : Nat) : a + 1 = Nat.succ a := by
-  sorry
+  rfl
 
 theorem bar (a b : Nat) : a + b = b + a := by
   rw[add_comm]


### PR DESCRIPTION
We identify the files containing theorems that have `sorry`, and replace them with a proof discovered by [Lean Copilot](https://github.com/lean-dojo/LeanCopilot).

---

<i>~LeanCopilotBot - From the [LeanDojo](https://leandojo.org/) family</i>

[:octocat: repo](https://github.com/lean-dojo/LeanCopilotBot) | [🙋🏾 issues](https://github.com/lean-dojo/LeanCopilotBot/issues) | [🏪 marketplace](https://github.com/marketplace/LeanCopilotBot)
